### PR TITLE
Improving AdditionalUsingDirectories resolving

### DIFF
--- a/cppcli-mfccontrols-lib/cppcli-mfccontrols-lib.props
+++ b/cppcli-mfccontrols-lib/cppcli-mfccontrols-lib.props
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="ExtractUsingPath"
+			  AfterTargets="ResolveAssemblyReferences"
+			  Condition="'$(CLRSupport)'=='NetCore'">
+    <ItemGroup>
+      <RefList Include="@(ReferencePath->'%(RootDir)%(Directory)')" Condition="'%(ReferencePath.NuGetPackageId)'=='Microsoft.WindowsDesktop.App.Ref'  And 
+                                   '%(ReferencePath.FileName)'=='System.Windows.Forms'"></RefList>
+      <ClCompile>
+        <AdditionalUsingDirectories>@(RefList);%(ClCompile.AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      </ClCompile>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/cppcli-mfccontrols-lib/cppcli-mfccontrols-lib.vcxproj
+++ b/cppcli-mfccontrols-lib/cppcli-mfccontrols-lib.vcxproj
@@ -27,6 +27,7 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <TargetFramework>net8.0</TargetFramework>
     <WindowsTargetPlatformMinVersion>7.0</WindowsTargetPlatformMinVersion>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -97,7 +98,6 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);DLL_CPPCLI_MFCCONTROLS_LIB_API=__declspec(dllexport)</PreprocessorDefinitions>
-      <AdditionalUsingDirectories>C:\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.8\ref\net8.0</AdditionalUsingDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
@@ -110,7 +110,6 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions);DLL_CPPCLI_MFCCONTROLS_LIB_API=__declspec(dllexport)</PreprocessorDefinitions>
-      <AdditionalUsingDirectories>C:\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.8\ref\net8.0</AdditionalUsingDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
@@ -123,7 +122,6 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions);DLL_CPPCLI_MFCCONTROLS_LIB_API=__declspec(dllexport)</PreprocessorDefinitions>
-      <AdditionalUsingDirectories>C:\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.8\ref\net8.0</AdditionalUsingDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
@@ -136,12 +134,16 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);DLL_CPPCLI_MFCCONTROLS_LIB_API=__declspec(dllexport)</PreprocessorDefinitions>
-      <AdditionalUsingDirectories>C:\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\8.0.8\ref\net8.0</AdditionalUsingDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies />
     </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+        <AdditionalUsingDirectories>$(ReferencePath);%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="cppcli-mfccontrols-lib.h" />
@@ -174,6 +176,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="cppcli-mfccontrols-lib.props" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>


### PR DESCRIPTION
Resolve path to `System.Windows.Forms.dll` in build time and add it to the AdditionalUsingDirectories property